### PR TITLE
Dead code elimination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
           command: |
             cargo run -- install
             cargo test -v
+    environment:
+      LLVM_SYS_60_PREFIX: /usr/lib/llvm-6.0
+
 
 workflows:
   version: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "1.0"
 failure = "0.1"
 log = "0.4"
 structopt = "0.2"
+llvm-sys = "60"
 
 [package.metadata.nvptx]
 runtime = ["core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ failure = "0.1"
 log = "0.4"
 structopt = "0.2"
 llvm-sys = "60"
+colored = "1"
 
 [package.metadata.nvptx]
 runtime = ["core"]

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -1,0 +1,111 @@
+use llvm_sys::bit_reader::*;
+use llvm_sys::core::*;
+use llvm_sys::prelude::*;
+
+use failure::err_msg;
+use std::ffi::*;
+use std::os::raw::c_char;
+use std::path::*;
+use std::ptr::null_mut;
+
+use error::*;
+
+struct MemoryBuffer(LLVMMemoryBufferRef);
+
+impl Drop for MemoryBuffer {
+    fn drop(&mut self) {
+        unsafe { LLVMDisposeMemoryBuffer(self.0) }
+    }
+}
+
+impl MemoryBuffer {
+    fn new(filename: &str) -> ResultAny<Self> {
+        let input = CString::new(filename)?;
+        let mut membuf: LLVMMemoryBufferRef = null_mut();
+        let mut msg: *mut c_char = null_mut();
+        let result = unsafe {
+            LLVMCreateMemoryBufferWithContentsOfFile(
+                input.into_raw(),
+                &mut membuf as *mut LLVMMemoryBufferRef,
+                &mut msg as *mut *mut c_char,
+            )
+        };
+        if result != 0 {
+            let msg = unsafe { CString::from_raw(msg) };
+            return Err(err_msg(format!("Canont read input: {:?}", msg)));
+        }
+        Ok(MemoryBuffer(membuf))
+    }
+}
+
+#[derive(Debug)]
+struct Module(LLVMModuleRef);
+
+#[derive(Debug)]
+struct Function(LLVMValueRef);
+
+impl Module {
+    fn parse_bitcode(buf: &MemoryBuffer) -> ResultAny<Self> {
+        let mut md: LLVMModuleRef = null_mut();
+        let res = unsafe { LLVMParseBitcode2(buf.0, &mut md as *mut _) };
+        if res != 0 {
+            return Err(err_msg("Cannot parse LLVM Bitcode"));
+        }
+        Ok(Module(md))
+    }
+
+    fn read_bitcode(filename: &str) -> ResultAny<Self> {
+        let membuf = MemoryBuffer::new(filename)?;
+        Self::parse_bitcode(&membuf)
+    }
+
+    fn functions(&self) -> Vec<Function> {
+        let mut funcs = Vec::new();
+        let mut f = unsafe { LLVMGetFirstFunction(self.0) };
+        while f != null_mut() {
+            funcs.push(Function(f));
+            f = unsafe { LLVMGetNextFunction(f) };
+        }
+        funcs
+    }
+}
+
+impl Function {
+    fn name(&self) -> String {
+        let name = unsafe { CString::from_raw(LLVMGetValueName(self.0) as *mut _) };
+        name.into_string().expect("Fail to parse function name")
+    }
+
+    // See the LLVM call convention list
+    //
+    // - PTX_Kernel = 71
+    // - PTX_Device = 72
+    //
+    // http://llvm.org/doxygen/CallingConv_8h_source.html
+    fn call_conv(&self) -> u32 {
+        unsafe { LLVMGetFunctionCallConv(self.0) }
+    }
+
+    fn is_ptx_kernel(&self) -> bool {
+        self.call_conv() == 71
+    }
+
+    fn is_ptx_device_func(&self) -> bool {
+        self.call_conv() == 72
+    }
+}
+
+pub fn get_ptx_functions<P: AsRef<Path>>(filename: P) -> ResultAny<Vec<String>> {
+    let path = filename.as_ref().to_str().unwrap();
+    let md = Module::read_bitcode(path)?;
+    Ok(md
+        .functions()
+        .into_iter()
+        .flat_map(|f| {
+            if f.is_ptx_kernel() || f.is_ptx_device_func() {
+                Some(f.name())
+            } else {
+                None
+            }
+        }).collect())
+}

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -100,12 +100,8 @@ pub fn get_ptx_functions<P: AsRef<Path>>(filename: P) -> ResultAny<Vec<String>> 
     let md = Module::read_bitcode(path)?;
     Ok(md
         .functions()
-        .into_iter()
-        .flat_map(|f| {
-            if f.is_ptx_kernel() || f.is_ptx_device_func() {
-                Some(f.name())
-            } else {
-                None
-            }
-        }).collect())
+        .iter()
+        .filter(|f| f.is_ptx_kernel() || f.is_ptx_device_func())
+        .map(|f| f.name())
+        .collect())
 }

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -98,10 +98,14 @@ impl Function {
 pub fn get_ptx_functions<P: AsRef<Path>>(filename: P) -> ResultAny<Vec<String>> {
     let path = filename.as_ref().to_str().unwrap();
     let md = Module::read_bitcode(path)?;
-    Ok(md
+    let ptx: Vec<_> = md
         .functions()
         .iter()
         .filter(|f| f.is_ptx_kernel() || f.is_ptx_device_func())
         .map(|f| f.name())
-        .collect())
+        .collect();
+    if ptx.len() == 0 {
+        return Err(err_msg("No PTX found"));
+    }
+    Ok(ptx)
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -7,7 +7,7 @@ use std::str::from_utf8;
 use std::{fs, io, process};
 use tempdir::TempDir;
 
-use super::{get_compiler_rt, save_str, TOOLCHAIN_NAME};
+use super::{bitcode, get_compiler_rt, save_str, TOOLCHAIN_NAME};
 use error::*;
 
 /// Compile Rust string into PTX string
@@ -98,6 +98,8 @@ impl Driver {
             .arg(target_dir.join("kernel.bc"))
             .current_dir(&target_dir)
             .check_run(Step::Link)?;
+        // TODO opt
+        let ptx_funcs = bitcode::get_ptx_functions(&target_dir.join("kernel.bc"));
         // compile bytecode to PTX
         process::Command::new(llvm_command("llc").log_unwrap(Step::Link)?)
             .args(&["-mcpu=sm_50", "kernel.bc", "-o", "kernel.ptx"])

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -117,15 +117,14 @@ impl Driver {
 
         // Internalize unused symbols
         eprintln!(
-            "{:>12} LLVM bitcodes ({}/{})",
-            "Optimizing".bright_green(),
+            "{:>12} unused bitcodes ({}/{})",
+            "Drop".bright_green(),
             self.target_dir_name(),
             opt_bc_name
         );
         let ptx_funcs = bitcode::get_ptx_functions(&target_dir.join(bc_name))
             .log(Step::Link, "Fail to parse LLVM bitcode")?;
         process::Command::new(llvm_command("opt").log(Step::Link, "opt not found")?)
-            .arg(if self.release { "-O3" } else { "" })
             .arg("-internalize")
             .arg(format!(
                 "-internalize-public-api-list={}",
@@ -143,6 +142,7 @@ impl Driver {
             ptx_name
         );
         process::Command::new(llvm_command("llc").log_unwrap(Step::Link)?)
+            .arg(if self.release { "-O3" } else { "-O0" })
             .args(&["-mcpu=sm_50", opt_bc_name, "-o", ptx_name])
             .current_dir(&target_dir)
             .check_run(Step::Link)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate log;
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;
+extern crate colored;
 extern crate dirs;
 extern crate glob;
 extern crate llvm_sys;
@@ -28,6 +29,7 @@ use std::path::Path;
 use std::{fs, io};
 
 const TOOLCHAIN_NAME: &'static str = "accel-nvptx";
+const TARGET_NAME: &'static str = "nvptx64-nvidia-cuda";
 
 pub(crate) fn save_str<P: AsRef<Path>>(path: P, contents: &str, filename: &str) -> io::Result<()> {
     let mut f = fs::File::create(path.as_ref().join(filename))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,13 @@ extern crate failure;
 extern crate serde_derive;
 extern crate dirs;
 extern crate glob;
+extern crate llvm_sys;
 extern crate serde;
 extern crate serde_json;
 extern crate tempdir;
 extern crate toml;
 
+mod bitcode;
 mod driver;
 pub mod error;
 pub mod manifest;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -4,7 +4,7 @@ use std::str::from_utf8;
 use std::{fs, process};
 use tempdir::TempDir;
 
-use super::TOOLCHAIN_NAME;
+use super::{TARGET_NAME, TOOLCHAIN_NAME};
 use driver::rlib2bc;
 use error::ResultAny;
 
@@ -19,11 +19,10 @@ pub fn install(path: &Path) -> ResultAny<()> {
     let rust_std = "rust-std";
     let rust_doc = "rust-docs";
     let x86 = "x86_64-unknown-linux-gnu";
-    let nvptx = "nvptx64-nvidia-cuda";
     let version = "1.28.0-dev";
     for cmp in &[rustc, rust_std, rust_doc] {
-        for target in &[x86, nvptx] {
-            if (cmp == &rustc) && (target == &nvptx) {
+        for target in &[x86, TARGET_NAME] {
+            if (cmp == &rustc) && (target == &TARGET_NAME) {
                 // rustc does not work on nvptx
                 continue;
             }
@@ -92,7 +91,10 @@ fn get_toolchain_path() -> ResultAny<PathBuf> {
 }
 
 fn get_nvptx_lib_path() -> ResultAny<PathBuf> {
-    Ok(get_toolchain_path()?.join("lib/rustlib/nvptx64-nvidia-cuda/lib"))
+    Ok(get_toolchain_path()?
+        .join("lib/rustlib")
+        .join(TARGET_NAME)
+        .join("lib"))
 }
 
 fn get_all_compiler_rt() -> ResultAny<Vec<PathBuf>> {


### PR DESCRIPTION
Drop unused symbols before generating PTX using `opt -globaldce`

- Use llvm-sys to find PTX functions (`extern ptx-kernel`) based on the LLVM calling-convention
  - PTX_Kernel = 71
  - PTX_Device = 72
  - See also: http://llvm.org/doxygen/CallingConv_8h_source.html
- Colored message from driver